### PR TITLE
[BUGFIX] Fixes Items on Mobile

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -760,6 +760,18 @@ header {
     .header-container > .btn{
         margin: 10px 0px;
     }
+    .img-layer {
+        position: absolute;
+        margin-left: 0;
+        margin-top: -20rem;
+        margin-right: -3rem;
+        align-items: center;
+        max-width: 100vw;
+        transform: rotateX(0deg) rotateY(300deg);
+    }
+    .img-layer img {
+        max-width: 50vw;
+    }
     .contrib-container{
         display: block;
         padding: 2.5rem 0;
@@ -777,7 +789,13 @@ header {
     .img-layer {
         opacity: 0.3;
     }
-
+    .download_section {
+        flex-direction: column;
+    }
+    .btn4 {
+        width: 100%;
+        font-size: 20px !important;
+    }
   .header-container {
     padding-top: 30px;
     margin: 5rem 2rem 2rem;
@@ -811,6 +829,13 @@ header {
   }
   .contrib-container .btn4 {
     text-align: center;
+  }
+  .download_section {
+    flex-direction: column;
+  }
+  .btn4 {
+    width: 80vw;
+    font-size: 20px !important;
   }
 }
 


### PR DESCRIPTION
Fixes the Issue #72 by:
- Resizing the text by changing the font size, flex direction
- Resizing the gif that caused overflow and made elements seem small in comparison