### PR TITLE
padding to nav-bar items and 'download here' section

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -508,6 +508,7 @@ header {
   text-align: center;
   background-color: var(--background-color);
   color: var(--black);
+  padding-top: 100px;
 }
 
 .download > h2 {
@@ -699,7 +700,7 @@ header {
   margin-top: 5%;
 }
 
-li {
+.footer li {
   margin-top: 8px;
   list-style-type: none;
   line-height: 180%;

--- a/Website/style.css
+++ b/Website/style.css
@@ -508,7 +508,7 @@ header {
   text-align: center;
   background-color: var(--background-color);
   color: var(--black);
-  padding-top: 100px;
+  padding-top: 50px;
 }
 
 .download > h2 {


### PR DESCRIPTION
for issue #164 . i have set padding to the nav-bar items and download section. 

**before:**

![image](https://user-images.githubusercontent.com/82041920/198307404-c85e8f66-2aca-49a0-a501-1825afba72e9.png)

![image](https://user-images.githubusercontent.com/82041920/198307571-e03d283a-7f6f-40f8-815b-e49a9ee53d6f.png)

**after:**

![image](https://user-images.githubusercontent.com/82041920/198307790-3a4d0340-104f-475b-9644-688af9200756.png)

![image](https://user-images.githubusercontent.com/82041920/198307846-497f2e5f-3fd6-4b22-be6d-e8a6f4fb69a6.png)


