### PR TITLE
Fix #159 Dockerize static website

### DIFF
--- a/Website/.dockerignore
+++ b/Website/.dockerignore
@@ -1,0 +1,4 @@
+.dockerignore
+docker-compose.yml
+Dockerfile
+README.md

--- a/Website/Dockerfile
+++ b/Website/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:stable-alpine
+COPY . /usr/share/nginx/html

--- a/Website/README.md
+++ b/Website/README.md
@@ -1,4 +1,5 @@
 # Website
+
 **A README file can be described as documentation with guidelines on how to use a project. 
 Usually it will have instructions on how to download, install, run and contribute to the project but we've already worked on it which is the main [README](https://github.com/SaptarshiSarkar12/Drifty/blob/master/README.md) file of our [project](https://github.com/SaptarshiSarkar12/Drifty).**
 
@@ -9,3 +10,31 @@ and lots of images (located in [Resources](https://github.com/SaptarshiSarkar12/
 
 - The website folder also contains files like HTML, CSS, and JavaScript by which you can make necessary changes in this project's website.
 
+## Docker Deployment
+
+Containerized website uses Nginx server.
+
+### Requirements
+
+* [Docker](https://docs.docker.com/get-docker/) (including [Docker Compose](https://docs.docker.com/compose/install/))
+
+### How to get started
+
+1. Easy! Build the image and run the container:
+
+    ```sh
+    docker-compose up -d --build
+    ```
+
+2. Navigate to http://localhost:8080/ to view the website.
+
+> **Note**  
+> Check for errors in the logs if this doesn't work via `docker-compose logs -f`.
+
+### Teardown
+
+Bring down the container:
+
+```sh
+docker-compose down
+```

--- a/Website/README.md
+++ b/Website/README.md
@@ -3,10 +3,8 @@
 **A README file can be described as documentation with guidelines on how to use a project. 
 Usually it will have instructions on how to download, install, run and contribute to the project but we've already worked on it which is the main [README](https://github.com/SaptarshiSarkar12/Drifty/blob/master/README.md) file of our [project](https://github.com/SaptarshiSarkar12/Drifty).**
 
-
 - This section contains information about how the [website of this project](https://saptarshisarkar12.github.io/Drifty/) looks like. You can see instruction videos, 
 and lots of images (located in [Resources](https://github.com/SaptarshiSarkar12/Drifty/tree/master/Website/Resources) folder) that are used to make the website.
-
 
 - The website folder also contains files like HTML, CSS, and JavaScript by which you can make necessary changes in this project's website.
 
@@ -25,8 +23,13 @@ Containerized website uses Nginx server.
     ```sh
     docker-compose up -d --build
     ```
-
-2. Navigate to http://localhost:8080/ to view the website.
+    
+    You may pull the [latest image of the website from Docker Hub](https://hub.docker.com/r/saptarshisarkar12/drifty-website) by using this command:
+    
+    ```sh
+    docker run --rm -d  -p 80:80/tcp saptarshisarkar12/drifty-website:latest
+    ```
+2. Navigate to http://localhost:80/ to view the website.
 
 > **Note**  
 > Check for errors in the logs if this doesn't work via `docker-compose logs -f`.

--- a/Website/docker-compose.yml
+++ b/Website/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  web:
+    build: .
+    restart: always
+    ports:
+      - "8080:80"


### PR DESCRIPTION
I've containerized the static website using the Nginx server. The resulting Docker image is very lightweight and ready for production use.

![image](https://user-images.githubusercontent.com/3858548/200191102-f389038e-c1e7-4d29-b99c-059080390b91.png)

Readme updated: https://github.com/naXa777/Drifty/tree/devops/docker/Website#readme