### PR TITLE
Overflow of Github buttons fixed

### DIFF
--- a/Website/style.css
+++ b/Website/style.css
@@ -912,6 +912,13 @@ h4{
     width: 80vw;
     font-size: 20px !important;
   }
+  .github {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+  }
 }
 
 @media screen and (max-width: 1345px) {

--- a/Website/style.css
+++ b/Website/style.css
@@ -25,6 +25,7 @@ button {
   color: var(--font-color1);
   text-decoration: none;
 }
+
 body {
   overflow-x: hidden !important;
 }


### PR DESCRIPTION
When switched to IPad, buttons of github div starts overflowing. 
2 reasons for occurence of recent opened issue (Github button and animation overflow)
One is fixed, one is remaining.

Before
![image](https://user-images.githubusercontent.com/30335924/228310511-7e8c45a9-2a3a-4c67-b3f0-4f693084c7ea.png)

After
![image](https://user-images.githubusercontent.com/30335924/228310672-cd9de354-fd25-4506-b1d1-49c0367ee594.png)
