### PR TITLE
Added tooltip on hover effect to mode switch icon

### DIFF
--- a/Website/index.html
+++ b/Website/index.html
@@ -42,8 +42,7 @@
           <a href="contact.html"><button class="button">Contact</button></a>
         </li>
         <li>
-          <div class="btn-toggle"><i id="symb" class="fa-solid fa-moon fb"><div class="mode-tooltip">Dark/Bright Mode</div></i>
-            
+          <div class="btn-toggle"><i id="symb" class="fa-solid fa-moon fb"><div class="mode-tooltip">Dark/Light Mode</div></i>            
           </div>
         </li>
       </ul>

--- a/Website/index.html
+++ b/Website/index.html
@@ -42,7 +42,9 @@
           <a href="contact.html"><button class="button">Contact</button></a>
         </li>
         <li>
-          <div class="btn-toggle"><i id="symb" class="fa-solid fa-moon fb"></i></div>
+          <div class="btn-toggle"><i id="symb" class="fa-solid fa-moon fb"><div class="mode-tooltip">Dark/Bright Mode</div></i>
+            
+          </div>
         </li>
       </ul>
     </nav>

--- a/Website/style.css
+++ b/Website/style.css
@@ -1070,6 +1070,30 @@ h4 {
   cursor: pointer;
 }
 
+.fb .mode-tooltip{
+  
+  position: absolute;
+  background-color: rgb(9 219 244);
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  color: #100f0f;
+  bottom: 5px;
+  right: 95px;
+  border-radius: 8px;
+  font-size: 12px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  font-family: sans-serif;
+  pointer-events: none;
+}
+
+.fb:hover .mode-tooltip{
+  opacity: 1;
+  transition: opacity 0.35s;
+}
+
 .Txt {
   font-size: small;
 }


### PR DESCRIPTION
Initially, no tooltip was present during the hover effect for the mode selector icon.


https://user-images.githubusercontent.com/92843270/232592965-67317af1-5c87-42ac-a60e-e1bfdc0ebd4b.mp4


It is updated by adding a tooltip during the hover effect for the mode selector icon.


![with tooltip](https://user-images.githubusercontent.com/92843270/232594061-63c1a494-6068-4607-aa54-d389bae8767c.gif)
