### PR TITLE
feat: added copa to patch all docker image vulnerabilities reported by trivy

### DIFF
--- a/.github/workflows/dev-docker-build.yml
+++ b/.github/workflows/dev-docker-build.yml
@@ -28,43 +28,33 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Pull runtime os image # to patch vulnerabilities
+        if: matrix.os == 'ubuntu-latest'
+        run: docker pull oraclelinux:9-slim
+      - name: Build latest version of Copa # to support Oracle Linux yum packages
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          git clone https://github.com/project-copacetic/copacetic
+          cd copacetic
+          make
+          sudo mv dist/linux_amd64/release/copa /usr/local/bin/
+      - name: Run Copa to patch vulnerabilities
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          docker run --detach --rm --privileged --name buildkitd --entrypoint buildkitd moby/buildkit:latest
+          copa patch -i oraclelinux:9-slim -t 9-slim --addr docker-container://buildkitd --ignore-errors
+          docker stop buildkitd
       - name: Build Docker image
         run: |
           docker compose build base
           docker compose build runner
           docker compose build ${{ matrix.image_name_suffix }}
-      - name: Run Trivy security scan on original image
+      - name: Run Trivy security scan
+        if: matrix.os == 'ubuntu-latest'
         uses: aquasecurity/trivy-action@0.24.0
         continue-on-error: true
         with:
-          image-ref: drifty-${{ matrix.image_name_suffix }}
-          format: 'json'
-          exit-code: 1
-          vuln-type: os
-          ignore-unfixed: true
-          output: 'report.json'
-          hide-progress: false
-          scanners: vuln
-      - name: Check OS vulnerability count
-        id: vuln_count
-        run: |
-          report_file="report.json"
-          vuln_count=$(jq 'if .Results then [.Results[] | select(.Class=="os-pkgs" and .Vulnerabilities!=null) | .Vulnerabilities[]] | length else 0 end' "$report_file")
-          echo "vuln_count=$vuln_count" >> $GITHUB_OUTPUT
-      # copa action will only run if there are vulnerabilities
-      - name: Run Copa action to patch OS vulnerabilities
-        if: steps.vuln_count.outputs.vuln_count != '0'
-        uses: project-copacetic/copa-action@v1.2.1
-        with:
-          image: drifty-${{ matrix.image_name_suffix }}
-          image-report: "report.json"
-          patched-tag: "patched"
-          timeout: '10m'
-      - name: Run Trivy security scan on patched image
-        uses: aquasecurity/trivy-action@0.24.0
-        continue-on-error: true
-        with:
-          image-ref: "drifty-${{ matrix.image_name_suffix }}:patched"
+          image-ref: "drifty-${{ matrix.image_name_suffix }}"
           format: 'sarif'
           exit-code: 1
           vuln-type: os,library
@@ -73,7 +63,7 @@ jobs:
           hide-progress: false
           scanners: vuln,secret,misconfig
       - name: Upload Trivy security scan results
-        if: always()
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: github/codeql-action/upload-sarif@main
         with:
           sarif_file: trivy-report.sarif

--- a/.github/workflows/dev-docker-build.yml
+++ b/.github/workflows/dev-docker-build.yml
@@ -33,11 +33,38 @@ jobs:
           docker compose build base
           docker compose build runner
           docker compose build ${{ matrix.image_name_suffix }}
-      - name: Run Trivy security scan
+      - name: Run Trivy security scan on original image
         uses: aquasecurity/trivy-action@0.24.0
         continue-on-error: true
         with:
           image-ref: drifty-${{ matrix.image_name_suffix }}
+          format: 'json'
+          exit-code: 1
+          vuln-type: os
+          ignore-unfixed: true
+          output: 'report.json'
+          hide-progress: false
+          scanners: vuln
+      - name: Check OS vulnerability count
+        id: vuln_count
+        run: |
+          report_file="report.json"
+          vuln_count=$(jq 'if .Results then [.Results[] | select(.Class=="os-pkgs" and .Vulnerabilities!=null) | .Vulnerabilities[]] | length else 0 end' "$report_file")
+          echo "vuln_count=$vuln_count" >> $GITHUB_OUTPUT
+      # copa action will only run if there are vulnerabilities
+      - name: Run Copa action to patch OS vulnerabilities
+        if: steps.vuln_count.outputs.vuln_count != '0'
+        uses: project-copacetic/copa-action@v1.2.1
+        with:
+          image: drifty-${{ matrix.image_name_suffix }}
+          image-report: "report.json"
+          patched-tag: "patched"
+          timeout: '10m'
+      - name: Run Trivy security scan on patched image
+        uses: aquasecurity/trivy-action@0.24.0
+        continue-on-error: true
+        with:
+          image-ref: "drifty-${{ matrix.image_name_suffix }}:patched"
           format: 'sarif'
           exit-code: 1
           vuln-type: os,library

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -163,7 +163,19 @@ jobs:
           else
             echo "IMAGE_DESCRIPTION_PREFIX=The" >> $GITHUB_ENV
           fi
-
+      - name: Pull runtime os image # to patch vulnerabilities
+        run: docker pull oraclelinux:9-slim
+      - name: Build latest version of Copa # to support Oracle Linux yum packages
+        run: |
+          git clone https://github.com/project-copacetic/copacetic
+          cd copacetic
+          make
+          sudo mv dist/linux_amd64/release/copa /usr/local/bin/
+      - name: Run Copa to patch vulnerabilities
+        run: |
+          docker run --detach --rm --privileged --name buildkitd --entrypoint buildkitd moby/buildkit:latest
+          copa patch -i oraclelinux:9-slim -t 9-slim --addr docker-container://buildkitd --ignore-errors
+          docker stop buildkitd
       # Build and push Docker image with Buildx (don't push on PR and branches created by Dependabot)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -183,7 +195,7 @@ jobs:
             annotation-index.org.opencontainers.image.description=${{ env.IMAGE_DESCRIPTION_PREFIX }} docker image for Drifty ${{ matrix.docker_context }},\
             annotation-index.org.opencontainers.image.licenses=Apache-2.0"
 
-      - name: Build same image with different tag # cached build, so, will be faster, and it will be used for security scan
+      - name: Build same image with different name # cached build, so, will be faster, and it will be used for security scan
         run: docker build -t ${{ matrix.image_name }} -f Docker/prod/${{ matrix.docker_context }}/Dockerfile build/${{ matrix.docker_context }}
 
       - name: Run Trivy security scan


### PR DESCRIPTION
## Fixes issue

<!-- If your PR fixes an open issue, use `Fixes #ISSUE_NUMBER` to link your PR with the issue. -->

Fixes #627 

## Changes proposed

This PR modified the `dev-docker-build` and `docker-publish` workflows to add support for capo to patch all the supported vulnerabilities in the runtime OS of the docker images `drifty-cli` and `drifty-gui`.

## Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced GitHub Actions workflows for improved security and build processes.
	- Introduced steps to pull Oracle Linux images and build the latest version of the Copa tool.
	- Added functionality for vulnerability patching in Docker containers.

- **Bug Fixes**
	- Adjusted conditions for running security scans to ensure they execute only in Ubuntu environments.

- **Documentation**
	- Clarified naming in workflow steps for better understanding of processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->