### PR TITLE
Fix: Enhanced Filtering for Pre-releases

### DIFF
--- a/Website/app/Releases.js
+++ b/Website/app/Releases.js
@@ -148,13 +148,28 @@ export default function Releases({ props }) {
   }, [props.release]);
   const filteredPreReleases = useMemo(() => {
     const releases = [];
-    props.release.map((item) => {
-      if (item.prerelease === true && releases.length < 1) {
-        releases.push(item); // Only one pre-release is collected.
+    
+    // Get the latest stable version
+    let latestStableVersion = props.release.find(item => !item.prerelease)?.tag_name;
+  
+    props.release.forEach((item) => {
+      // Skip the pre-release if a stable version with the same base version exists
+      const baseVersion = item.tag_name.split('-')[0]; // Extract the base version (e.g., v2.1.0 from v2.1.0-rc.1)
+      
+      if (
+        item.prerelease &&
+        latestStableVersion &&
+        baseVersion === latestStableVersion // Compare base versions
+      ) {
+        return; // Skip pre-releases if a stable version with the same base exists
+      }
+  
+      if (item.prerelease && releases.length < 1) {
+        releases.push(item); // Only add one pre-release
       }
     });
     return releases;
-  }, [props.release]);
+  }, [props.release]);  
   const filteredReleases = useMemo(() => {
     // Starting from v2.0.0, separate executables for windows, linux and macOS are available. So, we need three buttons (in total) in that case.
     const releases = [];
@@ -368,15 +383,7 @@ export default function Releases({ props }) {
                 <span className="font-bold">{item.tag_name} </span>
                 <p>
                   {new Date(item.published_at).toString()} with{" "}
-                  {item.assets[0].download_count +
-                    item.assets[1].download_count +
-                    item.assets[2].download_count +
-                    item.assets[3].download_count +
-                    item.assets[4].download_count +
-                    item.assets[5].download_count +
-                    item.assets[6].download_count +
-                    item.assets[7].download_count +
-                    item.assets[8].download_count}{" "}
+                  {item.assets?.reduce((sum, asset) => sum + (asset.download_count || 0), 0)}{" "}
                   Downloads
                 </p>
                 <button

--- a/Website/app/Releases.js
+++ b/Website/app/Releases.js
@@ -150,7 +150,8 @@ export default function Releases({ props }) {
     const releases = [];
     
     // Get the latest stable version
-    let latestStableVersion = props.release.find(item => !item.prerelease)?.tag_name;
+    const sortedReleases = [...props.release].sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+    let latestStableVersion = sortedReleases.find(item => !item.prerelease)?.tag_name;
   
     props.release.forEach((item) => {
       // Skip the pre-release if a stable version with the same base version exists

--- a/Website/app/Releases.js
+++ b/Website/app/Releases.js
@@ -155,7 +155,7 @@ export default function Releases({ props }) {
   
     props.release.forEach((item) => {
       // Skip the pre-release if a stable version with the same base version exists
-      const baseVersion = item.tag_name.split('-')[0]; // Extract the base version (e.g., v2.1.0 from v2.1.0-rc.1)
+      const baseVersion = item.tag_name.match(/^v?\d+\.\d+\.\d+/)?.[0]; // Match semantic versioning pattern
       
       if (
         item.prerelease &&


### PR DESCRIPTION
## Fixes issue

<!-- If your PR fixes an open issue, use `Fixes #ISSUE_NUMBER` to link your PR with the issue. -->

Fixes #670 

## Changes proposed

Fixed issue where pre-release versions (e.g., v2.1.0-rc.1) were shown even after the stable version (v2.1.0) was released.

- Added logic to filter out pre-releases if a stable version with the same base version (e.g., v2.1.0) exists.
- Extracted base version from the release tag using split('-')[0] to compare stable and pre-release versions.
- Ensured only one pre-release is shown when no corresponding stable release exists.

<!-- List all the proposed changes in your PR -->

## Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://github.com/user-attachments/assets/2ecc7e03-9009-4e67-9ddd-43cebf7dd5ce)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced filtering for pre-releases, ensuring only relevant versions are displayed alongside stable releases.
	- Improved calculation of total download counts for pre-releases, resulting in clearer information for users.

- **Bug Fixes**
	- Adjusted filtering logic to maintain consistency with new pre-release handling.

These updates improve the user experience by providing more accurate release information and download statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->