### PR TITLE
Add legal-use disclaimer to README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ To mark Drifty as safe:
 
 ## 🛡️ Legal Disclaimer
 
-This software is provided for downloading content that **you have legal rights to access**. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
+This software is provided for downloading content that **you have the legal right to access**. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
 
-The developers and contributors are **not responsible for misuse**. This tool is intended solely for educational and personal use.
+The developers and contributors are **not responsible for any misuse of this tool**. This tool is intended primarily for educational and personal use.
 
 By using Drifty, you agree to use it **legally and responsibly**.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ To mark Drifty as safe:
   ```
   Try running Drifty again.
 
+## 🛡️ Legal Disclaimer
+
+This software is provided for downloading content that **you have legal rights to access**. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
+
+The developers and contributors are **not responsible for misuse**. This tool is intended solely for educational and personal use.
+
+By using Drifty, you agree to use it **legally and responsibly**.
+
 ## 🤝 Contributing
 
 We welcome all contributions! Here’s how you can help:

--- a/Website/app/disclaimer/page.tsx
+++ b/Website/app/disclaimer/page.tsx
@@ -1,6 +1,6 @@
 export default async function Disclaimer() {
   const response = await fetch(
-    "https://raw.githubusercontent.com/AvinashAbbigeri/Drifty/disclaimers/disclaimer.txt",
+    "https://raw.githubusercontent.com/SaptarshiSarkar12/Drifty/master/disclaimer.txt",
   );
   const content = await response.text();
 

--- a/Website/app/disclaimer/page.tsx
+++ b/Website/app/disclaimer/page.tsx
@@ -1,0 +1,15 @@
+export default async function Disclaimer() {
+  const response = await fetch(
+    "https://raw.githubusercontent.com/AvinashAbbigeri/Drifty/disclaimers/disclaimer.txt",
+  );
+  const content = await response.text();
+
+  return (
+    <div className="max-w-3xl mx-auto py-10 px-2 sm:px-4 lg:px-6">
+      <h1 className="text-3xl font-bold text-center mb-6">Disclaimer</h1>
+      <pre className="bg-gray-100 dark:bg-gray-800 text-gray-800 dark:text-gray-200 p-4 rounded-lg whitespace-pre-wrap border border-gray-300 dark:border-gray-700 text-sm sm:text-base leading-relaxed overflow-x-auto">
+        {content}
+      </pre>
+    </div>
+  );
+}

--- a/Website/components/Footer.tsx
+++ b/Website/components/Footer.tsx
@@ -13,7 +13,7 @@ export default function Footer() {
           </p>
         </div>
 
-        <ul className="flex-1 flex flex-wrap justify-center md:justify-center space-x-6 text-sm font-medium">
+        <ul className="flex-auto flex flex-wrap justify-center md:justify-center space-x-4 text-sm font-medium">
           <li>
             <DarkModeToggle />
           </li>
@@ -39,6 +39,14 @@ export default function Footer() {
               className="hover:underline transition-all transform hover:scale-105"
             >
               Contact
+            </Link>
+          </li>
+          <li>
+            <Link
+              href="/disclaimer"
+              className="hover:underline transition-all transform hover:scale-105"
+            >
+              Disclaimer
             </Link>
           </li>
         </ul>

--- a/Website/package-lock.json
+++ b/Website/package-lock.json
@@ -289,14 +289,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/disclaimer.txt
+++ b/disclaimer.txt
@@ -1,8 +1,8 @@
 Disclaimer
 ==============
 
-This software is provided for downloading content that **you have legal rights to access**. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
+This software is provided for downloading content that you have legal rights to access. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
 
-The developers and contributors are **not responsible for misuse**. This tool is intended solely for educational and personal use.
+The developers and contributors are not responsible for misuse. This tool is intended solely for educational and personal use.
 
-By using Drifty, you agree to use it **legally and responsibly**.
+By using Drifty, you agree to use it legally and responsibly.

--- a/disclaimer.txt
+++ b/disclaimer.txt
@@ -1,8 +1,8 @@
 Disclaimer
 ==============
 
-This software is provided for downloading content that you have legal rights to access. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
+This software is provided for downloading content that you have the legal right to access. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
 
-The developers and contributors are not responsible for misuse. This tool is intended solely for educational and personal use.
+The developers and contributors are not responsible for any misuse of this tool. This tool is intended primarily for educational and personal use.
 
 By using Drifty, you agree to use it legally and responsibly.

--- a/disclaimer.txt
+++ b/disclaimer.txt
@@ -1,0 +1,8 @@
+Disclaimer
+==============
+
+This software is provided for downloading content that **you have legal rights to access**. Usage of Drifty must comply with all applicable copyright laws and the Terms of Service of any platforms involved.
+
+The developers and contributors are **not responsible for misuse**. This tool is intended solely for educational and personal use.
+
+By using Drifty, you agree to use it **legally and responsibly**.


### PR DESCRIPTION
Fixes #945

## Changes

- Added a disclaimer to the README file

- Created a new disclaimer page on the website

- Linked the page in the footer

- Loaded disclaimer content from GitHub raw link

Note : Disclaimer text is currently loaded from my fork. Once this PR is merged, we can update the link to point to the main repo.

## Preview Deployment
Deployment link: https://drifty-git-fork-avinashabbige-6b7ca1-saptarshi-sarkars-projects.vercel.app/