### PR TITLE
bug: handles null pointer exception in youtububeorinstagram method in…

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Lint Code Base
-    if: github.repository == 'SaptarshiSarkar12/Drifty'
+    #if: github.repository == 'SaptarshiSarkar12/Drifty'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/GUI/src/main/java/backend/FileDownloader.java
+++ b/GUI/src/main/java/backend/FileDownloader.java
@@ -112,7 +112,7 @@ public class FileDownloader extends Task<Integer> {
         }
         updateProgress(0.0, 1.0);
         done = true;
-        return   exitCode;
+        return exitCode;
     }
 
     private void downloadYoutubeOrInstagram(boolean isSpotifySong) {

--- a/GUI/src/main/java/backend/FileDownloader.java
+++ b/GUI/src/main/java/backend/FileDownloader.java
@@ -113,6 +113,7 @@ public class FileDownloader extends Task<Integer> {
         updateProgress(0.0, 1.0);
         done = true;
         return exitCode;
+        //no extra space
     }
 
     private void downloadYoutubeOrInstagram(boolean isSpotifySong) {

--- a/GUI/src/main/java/backend/FileDownloader.java
+++ b/GUI/src/main/java/backend/FileDownloader.java
@@ -120,14 +120,14 @@ public class FileDownloader extends Task<Integer> {
         ProcessBuilder processBuilder = new ProcessBuilder(fullCommand);
         sendInfoMessage(String.format(DOWNLOADING_F, filename));
         Process process = null;
-        int exitCode=-1;
+        int exitCode = -1;
         try {
             process = processBuilder.start();
         } catch (IOException e) {
             M.msgDownloadError("Failed to start download process for \"" + filename + "\"");
             return;
         } catch (Exception e) {
-            String msg = e.getMessage() !=null ? e.getMessage():"";
+            String msg = e.getMessage() != null ? e.getMessage() : "";
             String[] messageArray = msg.split(",");
             if (messageArray.length >= 1 && messageArray[0].toLowerCase().trim().replaceAll(" ", "").contains("cannotrunprogram")) { // If yt-dlp program is not marked as executable
                 M.msgDownloadError(DRIFTY_COMPONENT_NOT_EXECUTABLE_ERROR);

--- a/GUI/src/main/java/backend/FileDownloader.java
+++ b/GUI/src/main/java/backend/FileDownloader.java
@@ -113,7 +113,6 @@ public class FileDownloader extends Task<Integer> {
         updateProgress(0.0, 1.0);
         done = true;
         return exitCode;
-        //no extra space
     }
 
     private void downloadYoutubeOrInstagram(boolean isSpotifySong) {
@@ -121,7 +120,6 @@ public class FileDownloader extends Task<Integer> {
         ProcessBuilder processBuilder = new ProcessBuilder(fullCommand);
         sendInfoMessage(String.format(DOWNLOADING_F, filename));
         Process process = null;
-        int exitCode = -1;
         try {
             process = processBuilder.start();
         } catch (IOException e) {

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,2 +1,0 @@
-[.ShellClassInfo]
-LocalizedResourceName=@Drifty,0

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@Drifty,0


### PR DESCRIPTION
This PR fixes a NullPointerException that could occur if the download process failed to start. 
The method now safely checks if the process was successfully created before attempting to read its output or wait for completion.

Fixes #959 

