### PR TITLE
chore: upgraded macOS github actions runner images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
     needs: fetch-drifty-version
     strategy:
       matrix:
-        os: ["windows-latest", "macos-14", "ubuntu-latest", "macos-13"] # macOS 14 is Apple Silicon, macOS 13 is Intel
+        os: ["windows-latest", "macos-15", "ubuntu-latest", "macos-15-intel"]
         mode: ["CLI", "GUI"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
@@ -112,7 +112,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        arch: ${{ matrix.os == 'macos-14' && 'aarch64' || 'x86_64' }}
+        arch: ${{ matrix.os == 'macos-15' && 'aarch64' || 'x86_64' }}
         jdk: 'java23'
     - name: Package Drifty CLI for ${{ matrix.os }} with GraalVM
       if: ${{ matrix.mode == 'CLI' }}
@@ -161,7 +161,7 @@ jobs:
             mv "GUI/target/gluonfx/x86_64-windows/Drifty-GUI.exe" build/GUI
         fi
     - name: Categorise build artifacts for macOS (Apple Silicon)
-      if: ${{ matrix.os == 'macos-14' }}
+      if: ${{ matrix.os == 'macos-15' }}
       run: |
         if ${{ matrix.mode == 'CLI' }}; then
             mv "CLI/target/CLI/macos/Drifty CLI" "CLI/target/CLI/macos/Drifty-CLI_macos_aarch64"
@@ -173,7 +173,7 @@ jobs:
             mv "GUI/target/gluonfx/aarch64-darwin/Drifty-GUI_aarch64.app" build/GUI
         fi
     - name: Categorise build artifacts for macOS (Intel)
-      if: ${{ matrix.os == 'macos-13' }}
+      if: ${{ matrix.os == 'macos-15-intel' }}
       run: |
         if ${{ matrix.mode == 'CLI' }}; then
             mv "CLI/target/CLI/macos/Drifty CLI" "CLI/target/CLI/macos/Drifty-CLI_macos_x86_64"
@@ -250,10 +250,10 @@ jobs:
       run: |
         tar -xvf ubuntu-latest-CLI-Build-Files/ubuntu-latest-CLI.tar -C linux
         tar -xvf ubuntu-latest-GUI-Build-Files/ubuntu-latest-GUI.tar -C linux
-        tar -xvf macos-14-CLI-Build-Files/macos-14-CLI.tar -C macos_aarch64
-        tar -xvf macos-14-GUI-Build-Files/macos-14-GUI.tar -C macos_aarch64
-        tar -xvf macos-13-CLI-Build-Files/macos-13-CLI.tar -C macos_x86_64
-        tar -xvf macos-13-GUI-Build-Files/macos-13-GUI.tar -C macos_x86_64
+        tar -xvf macos-15-CLI-Build-Files/macos-15-CLI.tar -C macos_aarch64
+        tar -xvf macos-15-GUI-Build-Files/macos-15-GUI.tar -C macos_aarch64
+        tar -xvf macos-15-intel-CLI-Build-Files/macos-15-intel-CLI.tar -C macos_x86_64
+        tar -xvf macos-15-intel-GUI-Build-Files/macos-15-intel-GUI.tar -C macos_x86_64
         tar -xvf windows-latest-CLI-Build-Files/windows-latest-CLI.tar -C windows
         tar -xvf windows-latest-GUI-Build-Files/windows-latest-GUI.tar -C windows
     - name: Get Size of Build Artifacts

--- a/.github/workflows/dev-docker-build.yml
+++ b/.github/workflows/dev-docker-build.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository == 'SaptarshiSarkar12/Drifty'
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'macos-13', 'macos-14', 'windows-latest' ] # macos-13 is AMD64 and macos-14 is ARM64
+        os: [ 'ubuntu-latest', 'macos-15-intel', 'macos-15', 'windows-latest' ]
         image_name_suffix: [ 'cli', 'gui' ]
       fail-fast: false
     permissions:

--- a/CLI/pom.xml
+++ b/CLI/pom.xml
@@ -113,7 +113,7 @@
         </profile>
         <!-- [macOS ARM] CLI native image builder profile -->
         <profile>
-            <id>build-drifty-cli-for-macos-14</id>
+            <id>build-drifty-cli-for-macos-15</id>
             <properties>
                 <resource-config-file>resource-config-macos-aarch64.json</resource-config-file>
             </properties>
@@ -153,7 +153,7 @@
         </profile>
         <!-- [macOS Intel] CLI native image builder profile -->
         <profile>
-            <id>build-drifty-cli-for-macos-13</id>
+            <id>build-drifty-cli-for-macos-15-intel</id>
             <properties>
                 <resource-config-file>resource-config-macos-x64.json</resource-config-file>
             </properties>

--- a/GUI/pom.xml
+++ b/GUI/pom.xml
@@ -86,11 +86,11 @@
     <profiles>
         <!-- [macOS ARM64] GUI native image builder profile -->
         <profile>
-            <id>build-drifty-gui-for-macos-14</id>
+            <id>build-drifty-gui-for-macos-15</id>
             <properties>
                 <package.type>pkg</package.type>
                 <system-native-image-arg>-Dsvm.platform=org.graalvm.nativeimage.Platform$MACOS_AARCH64</system-native-image-arg>
-                <system-linker-arg>${pom.parent.basedir}/config/missing_symbols-macos-14.o</system-linker-arg>
+                <system-linker-arg>${pom.parent.basedir}/config/missing_symbols-macos-15.o</system-linker-arg>
                 <resource-config-file>resource-config-macos-aarch64.json</resource-config-file>
                 <compatibility-arg>-march=compatibility</compatibility-arg>
                 <capcache-arg1>-H:CAPCacheDir=/tmp/cap</capcache-arg1>
@@ -100,11 +100,11 @@
         </profile>
         <!-- [macOS x86_64] GUI native image builder profile -->
         <profile>
-            <id>build-drifty-gui-for-macos-13</id>
+            <id>build-drifty-gui-for-macos-15-intel</id>
             <properties>
                 <package.type>pkg</package.type>
                 <system-native-image-arg>-Dsvm.platform=org.graalvm.nativeimage.Platform$MACOS_AMD64</system-native-image-arg>
-                <system-linker-arg>${pom.parent.basedir}/config/missing_symbols-macos-13.o</system-linker-arg>
+                <system-linker-arg>${pom.parent.basedir}/config/missing_symbols-macos-15-intel.o</system-linker-arg>
                 <resource-config-file>resource-config-macos-x64.json</resource-config-file>
                 <compatibility-arg>-march=compatibility</compatibility-arg>
                 <mac.app.store>true</mac.app.store>

--- a/Website/content/development/building-executables.mdx
+++ b/Website/content/development/building-executables.mdx
@@ -110,13 +110,13 @@ There are two ways to build the installer or executable binaries for Drifty GUI 
         <Tabs.Tab>
           {/* prettier-ignore */}
           ```shell
-          gcc -c config/missing_symbols.c -o config/missing_symbols-macos-14.o
+          gcc -c config/missing_symbols.c -o config/missing_symbols-macos-15.o
           ```
         </Tabs.Tab>
         <Tabs.Tab>
           {/* prettier-ignore */}
           ```shell
-          gcc -c config/missing_symbols.c -o config/missing_symbols-macos-13.o
+          gcc -c config/missing_symbols.c -o config/missing_symbols-macos-15-intel.o
           ```
         </Tabs.Tab>
        </Tabs>
@@ -140,13 +140,13 @@ There are two ways to build the installer or executable binaries for Drifty GUI 
             <Tabs.Tab>
               {/* prettier-ignore */}
               ```shell
-              mvn -P build-drifty-gui-for-macos-14 gluonfx:build gluonfx:package -rf :GUI -U
+              mvn -P build-drifty-gui-for-macos-15 gluonfx:build gluonfx:package -rf :GUI -U
               ```
             </Tabs.Tab>
             <Tabs.Tab>
               {/* prettier-ignore */}
               ```shell
-              mvn -P build-drifty-gui-for-macos-13 gluonfx:build gluonfx:package -rf :GUI -U
+              mvn -P build-drifty-gui-for-macos-15-intel gluonfx:build gluonfx:package -rf :GUI -U
               ```
             </Tabs.Tab>
           </Tabs>
@@ -168,13 +168,13 @@ There are two ways to build the installer or executable binaries for Drifty GUI 
           <Tabs.Tab>
             {/* prettier-ignore */}
             ```shell
-            mvn -P build-drifty-cli-for-macos-14 package
+            mvn -P build-drifty-cli-for-macos-15 package
             ```
           </Tabs.Tab>
           <Tabs.Tab>
             {/* prettier-ignore */}
             ```shell
-            mvn -P build-drifty-cli-for-macos-13 package
+            mvn -P build-drifty-cli-for-macos-15-intel package
             ```
           </Tabs.Tab>
           </Tabs>


### PR DESCRIPTION
## Fixes issue

<!-- If your PR fixes an open issue, use `Fixes #ISSUE_NUMBER` to link your PR with the issue. -->

Fixes failing GitHub Actions workflow because of deprecation of `macos-13` runner image.

## Changes proposed

<!-- List all the proposed changes in your PR -->
- `macos-15-intel` runner image will now be used for macOS Intel based workflows
- `macos-15` runner image will now be used for Apple Silicon (ARM64) macOS runner

## Check List (Check all the applicable boxes)

- [X] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.